### PR TITLE
Feature: Forgot password page integration with API

### DIFF
--- a/src/pages/password-reset/forgot-password.tsx
+++ b/src/pages/password-reset/forgot-password.tsx
@@ -7,9 +7,10 @@ import FocusFlowHeader from '../../components/shared/FocusFlowHeader'
 import { toast } from 'react-hot-toast'
 import { useDispatch, useSelector } from 'react-redux'
 import { AppDispatch, RootState } from '../../redux/store'
-import { forgotPassword } from '../../redux/slice/authSlice'
+import { forgotPassword, clearError } from '../../redux/slice/authSlice'
 import { handleAxiosError } from '../../util/helpers'
 import { AxiosError } from 'axios'
+import { useEffect } from 'react'
 
 type FormData = {
     email: string
@@ -32,6 +33,11 @@ function ForgotPasswordPage() {
         mode: 'all',
         defaultValues: { email: '' },
     })
+
+    useEffect(() => {
+        dispatch(clearError())
+    }, [dispatch])
+
     const onSubmit = async (data: FieldValues) => {
         try {
             const { meta: responseData } = await dispatch(forgotPassword(data.email))

--- a/src/pages/password-reset/reset-password.tsx
+++ b/src/pages/password-reset/reset-password.tsx
@@ -5,15 +5,47 @@ import { passwordSchema } from '../../schema/password'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import FocusFlowHeader from '../../components/shared/FocusFlowHeader'
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch, RootState } from '../../redux/store'
+import { handleAxiosError } from '../../util/helpers'
+import { resetPassword } from '../../redux/slice/authSlice'
+import toast from 'react-hot-toast'
+import { useNavigate, useSearchParams} from 'react-router-dom'
+import { AxiosError } from 'axios'
 
 type FormData = z.infer<typeof passwordSchema>
 function ResetPasswordPage() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { loading, error } = useSelector((state: RootState) => state.auth)
+    const navigate = useNavigate()
+    const [searchParams] = useSearchParams();
+    const token = searchParams.get('token');
     const {
         register,
         handleSubmit,
         formState: { errors, isValid },
     } = useForm<FormData>({ resolver: zodResolver(passwordSchema), mode: 'all' })
-    const onSubmit = (data: FieldValues) => console.log(data)
+    const onSubmit = async (data: FieldValues) => {
+        try {
+            if (!token) {
+                toast.error('Token is required to reset password.')
+                return
+            }
+            const resetData = {
+                newPassword: data.password as string,
+                token,
+            }
+            const { meta: responseData } = await dispatch(resetPassword(resetData))
+            if (responseData.requestStatus === 'fulfilled') {
+                toast.success('Successfully reset your password!')
+                navigate('/login')
+            } else {
+                toast.error('Failed to reset your password. Please try again.')
+            }
+        } catch (error) {
+            handleAxiosError(error as AxiosError)
+        }
+    }
     return (
         <div className='className="w-full flex flex-col px-4 py-2 md:px-24 md:py-12 h-screen"'>
             <FocusFlowHeader />
@@ -36,7 +68,12 @@ function ResetPasswordPage() {
                     id="Confirm Password"
                     type="password"
                 />
-                <Button className="w-full text-xl" disabled={!isValid}>
+                {error && (
+                    <p className="text-red-500 text-sm mt-2">
+                        {typeof error === 'string' ? error : JSON.stringify(error)}
+                    </p>
+                )}
+                <Button className="w-full text-xl" isLoading={loading} disabled={!isValid}>
                     Submit
                 </Button>
             </form>

--- a/src/pages/password-reset/reset-password.tsx
+++ b/src/pages/password-reset/reset-password.tsx
@@ -10,7 +10,7 @@ import { AppDispatch, RootState } from '../../redux/store'
 import { handleAxiosError } from '../../util/helpers'
 import { resetPassword } from '../../redux/slice/authSlice'
 import toast from 'react-hot-toast'
-import { useNavigate, useSearchParams} from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { AxiosError } from 'axios'
 
 type FormData = z.infer<typeof passwordSchema>
@@ -18,8 +18,8 @@ function ResetPasswordPage() {
     const dispatch = useDispatch<AppDispatch>()
     const { loading, error } = useSelector((state: RootState) => state.auth)
     const navigate = useNavigate()
-    const [searchParams] = useSearchParams();
-    const token = searchParams.get('token');
+    const [searchParams] = useSearchParams()
+    const token = searchParams.get('token')
     const {
         register,
         handleSubmit,

--- a/src/redux/slice/authSlice.ts
+++ b/src/redux/slice/authSlice.ts
@@ -15,7 +15,7 @@ export const signupUser = createAsyncThunk(
         { rejectWithValue },
     ) => {
         try {
-            const response = await api.post(`/users`, userData)
+            const response = await api.post(`/auth/signup`, userData)
             return response.data
         } catch (error: any) {
             const errorMessage = error.response?.data?.message || 'Signup failed'
@@ -39,6 +39,37 @@ export const loginUser = createAsyncThunk(
             return response.data
         } catch (error: any) {
             const errorMessage = error.response?.data?.message || 'Login failed'
+            return rejectWithValue(
+                typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage),
+            )
+        }
+    },
+)
+
+export const forgotPassword = createAsyncThunk(
+    'auth/forgotPassword',
+    async (email: string, { rejectWithValue }) => {
+        try {
+            const response = await api.post(`/auth/forgot-password`, { email })
+            return response.data
+        } catch (error: any) {
+            const errorMessage =
+                error.response?.data?.message || 'Failed to send reset password link'
+            return rejectWithValue(
+                typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage),
+            )
+        }
+    },
+)
+
+export const resetPassword = createAsyncThunk(
+    'auth/resetPassword',
+    async (data: { newPassword: string; token: string }, { rejectWithValue }) => {
+        try {
+            const response = await api.post(`/auth/reset-password`, data)
+            return response.data
+        } catch (error: any) {
+            const errorMessage = error.response?.data?.message || 'Failed to reset password'
             return rejectWithValue(
                 typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage),
             )
@@ -91,6 +122,28 @@ const authSlice = createSlice({
                 state.token = action.payload.token
             })
             .addCase(loginUser.rejected, (state, action) => {
+                state.loading = false
+                state.error = action.payload
+            })
+            .addCase(forgotPassword.pending, state => {
+                state.loading = true
+                state.error = null
+            })
+            .addCase(forgotPassword.fulfilled, state => {
+                state.loading = false
+            })
+            .addCase(forgotPassword.rejected, (state, action) => {
+                state.loading = false
+                state.error = action.payload
+            })
+            .addCase(resetPassword.pending, state => {
+                state.loading = true
+                state.error = null
+            })
+            .addCase(resetPassword.fulfilled, state => {
+                state.loading = false
+            })
+            .addCase(resetPassword.rejected, (state, action) => {
                 state.loading = false
                 state.error = action.payload
             })

--- a/src/redux/slice/authSlice.ts
+++ b/src/redux/slice/authSlice.ts
@@ -96,6 +96,9 @@ const authSlice = createSlice({
                 state.user = JSON.parse(user)
             }
         },
+        clearError: state => {
+            state.error = null
+        },
     },
     extraReducers: builder => {
         builder
@@ -150,5 +153,5 @@ const authSlice = createSlice({
     },
 })
 
-export const { logout, restoreAuth } = authSlice.actions
+export const { clearError, logout, restoreAuth } = authSlice.actions
 export default authSlice.reducer


### PR DESCRIPTION
## Impelemented the forgot password page integration with API

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Hotfix
- [ ] UI/UX improvement

## Description

If a user or admin forgets the password to the app, they can click "Forgot Password" to initiate a secure process of resetting a password for the account thus, they can regain access to their existing accounts.

## Testing

- Navigate to the login page and click on the forgot password link 
- You are redirected to the page where you need to put in your email.
- After successfully submitting your email check your inbox for the reset password URL
- Create a new password and confirm it
- you are redirected to the login page and you can login with your new credentials

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings/errors.
