### PR TITLE
Refactor/get workspaces by user integration

### DIFF
--- a/src/components/card/WorkspaceCard.tsx
+++ b/src/components/card/WorkspaceCard.tsx
@@ -1,15 +1,17 @@
 import { Link } from 'react-router-dom'
 import { MdModeEditOutline } from 'react-icons/md'
 import { WorkspaceProps } from '../../util/interfaces'
+import { formatDate } from '../../util/helpers'
 
 export default function WorkspaceCard(props: WorkspaceProps) {
+    const formattedDate = formatDate(props.creationDate)
     return (
         <Link to="/workspace-details">
             <div className="border rounded-full border-gray-200 py-3 md:py-4">
                 <div className="flex justify-between items-center px-4 md:px-11">
                     <p className=" text-sm md:text-lg">{props.name}</p>
                     <div className="flex items-center gap-x-9">
-                        <span>{props.creationDate}</span>
+                        <span>{formattedDate}</span>
                         <button>
                             <MdModeEditOutline />
                         </button>

--- a/src/components/shared/Sidebar.tsx
+++ b/src/components/shared/Sidebar.tsx
@@ -14,26 +14,30 @@ export default function Sidebar() {
                     {/* The links that redirect to specific route will be added later */}
                     <div className="space-y-3">
                         <Link to="#">
-                            <img src={Home} className="h-7 w-7" />
+                            <img src={Home} className="h-7 w-7" alt="The home icon" />
                         </Link>
                         <Link to="#">
-                            <img src={Profile} className="h-7 w-7" />
-                        </Link>
-                    </div>
-                    <div>
-                        <Link to="#">
-                            <img src={SidebarImage} className="h-7 w-7" />
+                            <img src={Profile} className="h-7 w-7" alt="The profile icon" />
                         </Link>
                     </div>
                     <div>
                         <Link to="#">
-                            <img src={Notification} className="h-7 w-7" />
+                            <img src={SidebarImage} className="h-7 w-7" alt="The sidebar image" />
+                        </Link>
+                    </div>
+                    <div>
+                        <Link to="#">
+                            <img
+                                src={Notification}
+                                className="h-7 w-7"
+                                alt="The notification image"
+                            />
                         </Link>
                         <Link to="#">
-                            <img src={Download} className="h-7 w-7" />
+                            <img src={Download} className="h-7 w-7" alt="The download image" />
                         </Link>
                         <Link to="#">
-                            <img src={Settings} className="h-7 w-7" />
+                            <img src={Settings} className="h-7 w-7" alt="The settings image" />
                         </Link>
                     </div>
                 </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,10 @@ const api = axios.create({
 
 api.interceptors.request.use(
     async config => {
+        const token = localStorage.getItem('token')
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`
+        }
         return config
     },
     error => {

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -1,16 +1,18 @@
 import Sidebar from '../components/shared/Sidebar'
 import { FaPlus } from 'react-icons/fa6'
 import WorkspaceCard from '../components/card/WorkspaceCard'
-import { Workspaces } from '../util/interfaces'
-
-const workspaces: Workspaces[] | [] = [
-    { id: '1', name: 'The Gym', creationDate: '24/02/2024' },
-    { id: '2', name: 'Alu', creationDate: '30/03/2025' },
-    { id: '3', name: 'Kepler', creationDate: '29/06/2023' },
-    { id: '3', name: 'AUCA', creationDate: '09/11/2025' },
-]
-
+import { useDispatch, useSelector } from 'react-redux'
+import { AppDispatch, RootState } from '../redux/store'
+import { useEffect } from 'react'
+import { getWorkspacesByUser } from '../redux/slice/workspaceSlice'
 export default function WorkspacePage() {
+    const dispatch = useDispatch<AppDispatch>()
+    const { workspaces, error, loading } = useSelector((state: RootState) => state.workspaces)
+    useEffect(() => {
+        dispatch(getWorkspacesByUser())
+    }, [dispatch])
+    if (loading) return `loading`
+    if (error) return error
     return (
         <div>
             <div className="flex w-full">
@@ -31,11 +33,11 @@ export default function WorkspacePage() {
                         </div>
                         <div className="mt-7 flex flex-col gap-y-2">
                             {workspaces.length > 0 ? (
-                                workspaces.map(workspace => (
+                                workspaces.map(({ id, name, created_at: creationDate }) => (
                                     <WorkspaceCard
-                                        key={workspace.id}
-                                        name={workspace.name}
-                                        creationDate={workspace.creationDate}
+                                        key={id}
+                                        name={name}
+                                        creationDate={creationDate}
                                     ></WorkspaceCard>
                                 ))
                             ) : (

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
         try {
             const { meta: responseData } = await dispatch(loginUser(data))
             if (responseData.requestStatus === 'fulfilled') {
-                navigate('/dashboard')
+                navigate('/workspace')
                 toast.success('Successfully logged in!')
             } else {
                 toast.error('Login failed')

--- a/src/redux/slice/workspaceSlice.ts
+++ b/src/redux/slice/workspaceSlice.ts
@@ -1,0 +1,72 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import api from '../../lib/api'
+import { WorkspaceState } from '../../util/interfaces'
+
+const initialState: WorkspaceState = {
+    workspaces: [],
+    loading: false,
+    error: null,
+}
+export const createWorkspace = createAsyncThunk(
+    'workspaces',
+    async (workspaceName: { name: string }, { rejectWithValue }) => {
+        try {
+            const response = await api.post(`/workspaces`, workspaceName)
+            return response.data
+        } catch (error: any) {
+            const errorMessage = error.response?.data?.message || 'creating Workspace faile'
+            return rejectWithValue(
+                typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage),
+            )
+        }
+    },
+)
+export const getWorkspacesByUser = createAsyncThunk(
+    'workspace/getByUser',
+    async (_, { rejectWithValue }) => {
+        try {
+            const response = await api.get('workspaces')
+            return response.data
+        } catch (error: any) {
+            const errorMessage = error.response?.data?.message || 'Fetching workspaces failed'
+            return rejectWithValue(
+                typeof errorMessage === 'string' ? errorMessage : JSON.stringify(errorMessage),
+            )
+        }
+    },
+)
+
+const workspacesSlice = createSlice({
+    name: 'workspace',
+    initialState,
+    reducers: {},
+    extraReducers: builder => {
+        builder
+            .addCase(createWorkspace.pending, state => {
+                state.loading = true
+                state.error = null
+            })
+            .addCase(createWorkspace.fulfilled, (state, action) => {
+                state.loading = false
+                state.workspaces.push(action.payload.workspace)
+            })
+            .addCase(createWorkspace.rejected, (state, action) => {
+                state.loading = true
+                state.error = action.payload
+            })
+            .addCase(getWorkspacesByUser.pending, state => {
+                state.loading = true
+                state.error = null
+            })
+            .addCase(getWorkspacesByUser.fulfilled, (state, action) => {
+                state.loading = false
+                state.workspaces = action.payload
+            })
+            .addCase(getWorkspacesByUser.rejected, (state, action) => {
+                state.loading = true
+                state.error = action.payload
+            })
+    },
+})
+
+export default workspacesSlice.reducer

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit'
 import authReducer from './slice/authSlice'
 import counterReducer from './slice/counterSlice'
+import workspacesReducer from './slice/workspaceSlice'
 const store = configureStore({
     reducer: {
         counter: counterReducer,
         auth: authReducer,
+        workspaces: workspacesReducer,
     },
 })
 

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -7,3 +7,7 @@ export const handleAxiosError = (error: AxiosError) => {
         return error.message
     }
 }
+export const formatDate = (isoString: string): string => {
+    const date = new Date(isoString)
+    return date.toLocaleDateString('en-GB')
+}

--- a/src/util/interfaces.ts
+++ b/src/util/interfaces.ts
@@ -29,14 +29,23 @@ export enum UserRole {
     ADMIN = 'Admin',
     MEMBER = 'Member',
 }
-
+export interface WorkspaceForCreation {
+    id: string
+    name: string
+}
+export interface WorkspaceState {
+    workspaces: Workspace[]
+    loading: boolean
+    error: any
+}
 export interface WorkspaceProps {
     name: string
     creationDate: string
 }
 
-export interface Workspaces {
+export interface Workspace {
     id: string
     name: string
-    creationDate: string
+    created_at: string
+    updated_at: string
 }


### PR DESCRIPTION
## Integrate the getWorkspacesByUser functionality

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Hotfix
- [ ] UI/UX improvement

## Description

Integrated the getByWorkspacesByUser functionality, from the backend, into the frontend to fetch all the workspaces basing on the logged user.

## Testing

- Log in with these credentials :
  `email: amelbent2@gmail.com`
  `password: flow@123`
- Observe the display of the dynamically fetched workspace data
Test with invalid names to ensure validation errors are displayed correctly.

## Screenshots:

![image](https://github.com/user-attachments/assets/4b024f24-b191-4154-b859-0060fc383583)

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings/errors.
