### PR TITLE
Feat: add confirmation modal before time entry delete

### DIFF
--- a/src/components/shared/forms/EditTimeLog.tsx
+++ b/src/components/shared/forms/EditTimeLog.tsx
@@ -17,6 +17,7 @@ import { AppDispatch, RootState } from '@/redux/store'
 import { deleteTimeLogAPI, editTimeLogAPI } from '@/redux/slice/timeLogsSlice'
 import { AxiosError } from 'axios'
 import { useMultiSelector } from '@/hooks/useMultiSelector'
+import ConfirmationModal from '../modal/confirmationModal'
 
 export default function EditTimeLog({
     id,
@@ -34,6 +35,8 @@ export default function EditTimeLog({
     const [start, setStartTime] = useState<Date>(new Date(date))
     const [end, setEndTime] = useState<Date>(set(new Date(date), { ...splitTime(endTime) }))
     const [selectedProject, setSelectedProject] = useState<string | null>(project || null)
+    const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false)
+
     const buttonRef = useRef<HTMLDivElement>(null)
     const dispatch = useDispatch<AppDispatch>()
 
@@ -61,13 +64,7 @@ export default function EditTimeLog({
         },
         mode: 'all',
     })
-    useEffect(() => {
-        console.log('start', start, 'end', end)
-        if (start && end) {
-            setValue('startTime', start.toISOString())
-            setValue('endTime', end.toISOString())
-        }
-    }, [start, end])
+
     const handleProjectSelect = (projectId: string, displayName: string) => {
         setValue('projectId', projectId)
         setSelectedProject(displayName)
@@ -100,6 +97,9 @@ export default function EditTimeLog({
             handleAxiosError(error as AxiosError)
         }
     }
+
+    const toggleDeleteConfirmationModal = () => setIsConfirmationModalOpen(!isConfirmationModalOpen)
+
     const handleDelete = async () => {
         try {
             const { meta: response } = await dispatch(deleteTimeLogAPI({ id, workspaceId }))
@@ -111,8 +111,18 @@ export default function EditTimeLog({
             }
         } catch (error) {
             handleAxiosError(error as AxiosError)
+        } finally {
+            toggleDeleteConfirmationModal()
         }
     }
+
+    useEffect(() => {
+        console.log('start', start, 'end', end)
+        if (start && end) {
+            setValue('startTime', start.toISOString())
+            setValue('endTime', end.toISOString())
+        }
+    }, [start, end])
 
     return (
         <div>
@@ -176,13 +186,20 @@ export default function EditTimeLog({
                             variant="accent"
                             type="submit"
                             name="delete"
-                            onClick={handleDelete}
+                            onClick={toggleDeleteConfirmationModal}
                             disabled={timeLogLoading}
                         >
                             Delete
                         </Button>
                     </div>
                 </form>
+            </Modal>
+            <Modal
+                title="Are you sure you want to delete this time entry?"
+                isModalOpen={isConfirmationModalOpen}
+                onClose={toggleDeleteConfirmationModal}
+            >
+                <ConfirmationModal confirm={handleDelete} cancel={toggleDeleteConfirmationModal} />
             </Modal>
         </div>
     )

--- a/src/components/shared/forms/EditTimeLog.tsx
+++ b/src/components/shared/forms/EditTimeLog.tsx
@@ -5,7 +5,7 @@ import ProjectsList from '@/components/ui/ProjectsList'
 import { ChevronDown } from 'lucide-react'
 import { DateTimePicker } from '@/components/ui/DateTimePicker'
 import Input from '../ui/Input'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { MouseEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { EditTimeLogFormData, EditTimeLogSchema } from '@/schema/timelogs'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -98,8 +98,12 @@ export default function EditTimeLog({
         }
     }
 
-    const toggleDeleteConfirmationModal = () =>
-        setIsDeleteConfirmationModalOpen(!isDeleteConfirmationModalOpen)
+    const toggleDeleteConfirmationModal = () => setIsDeleteConfirmationModalOpen(!isDeleteConfirmationModalOpen)
+    
+    const handleOpenDeleteConfirmation = (e:MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
+        e.preventDefault();
+        toggleDeleteConfirmationModal()
+    }
 
     const handleDelete = async () => {
         try {
@@ -112,11 +116,11 @@ export default function EditTimeLog({
             }
         } catch (error) {
             handleAxiosError(error as AxiosError)
-        } finally {
+        } finally {         
             toggleDeleteConfirmationModal()
         }
     }
-
+  
     useEffect(() => {
         console.log('start', start, 'end', end)
         if (start && end) {
@@ -185,10 +189,10 @@ export default function EditTimeLog({
                         <Button
                             className="w-full cursor-pointer"
                             variant="accent"
-                            type="submit"
+                            type="button"
                             name="delete"
-                            onClick={toggleDeleteConfirmationModal}
-                            disabled={timeLogLoading}
+                            onClick={handleOpenDeleteConfirmation}
+                            disabled={timeLogLoading}         
                         >
                             Delete
                         </Button>

--- a/src/components/shared/forms/EditTimeLog.tsx
+++ b/src/components/shared/forms/EditTimeLog.tsx
@@ -98,10 +98,11 @@ export default function EditTimeLog({
         }
     }
 
-    const toggleDeleteConfirmationModal = () => setIsDeleteConfirmationModalOpen(!isDeleteConfirmationModalOpen)
-    
-    const handleOpenDeleteConfirmation = (e:MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
-        e.preventDefault();
+    const toggleDeleteConfirmationModal = () =>
+        setIsDeleteConfirmationModalOpen(!isDeleteConfirmationModalOpen)
+
+    const handleOpenDeleteConfirmation = (e: MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
+        e.preventDefault()
         toggleDeleteConfirmationModal()
     }
 
@@ -116,11 +117,11 @@ export default function EditTimeLog({
             }
         } catch (error) {
             handleAxiosError(error as AxiosError)
-        } finally {         
+        } finally {
             toggleDeleteConfirmationModal()
         }
     }
-  
+
     useEffect(() => {
         console.log('start', start, 'end', end)
         if (start && end) {
@@ -192,7 +193,7 @@ export default function EditTimeLog({
                             type="button"
                             name="delete"
                             onClick={handleOpenDeleteConfirmation}
-                            disabled={timeLogLoading}         
+                            disabled={timeLogLoading}
                         >
                             Delete
                         </Button>

--- a/src/components/shared/forms/EditTimeLog.tsx
+++ b/src/components/shared/forms/EditTimeLog.tsx
@@ -35,7 +35,7 @@ export default function EditTimeLog({
     const [start, setStartTime] = useState<Date>(new Date(date))
     const [end, setEndTime] = useState<Date>(set(new Date(date), { ...splitTime(endTime) }))
     const [selectedProject, setSelectedProject] = useState<string | null>(project || null)
-    const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false)
+    const [isDeleteConfirmationModalOpen, setIsDeleteConfirmationModalOpen] = useState(false)
 
     const buttonRef = useRef<HTMLDivElement>(null)
     const dispatch = useDispatch<AppDispatch>()
@@ -98,7 +98,8 @@ export default function EditTimeLog({
         }
     }
 
-    const toggleDeleteConfirmationModal = () => setIsConfirmationModalOpen(!isConfirmationModalOpen)
+    const toggleDeleteConfirmationModal = () =>
+        setIsDeleteConfirmationModalOpen(!isDeleteConfirmationModalOpen)
 
     const handleDelete = async () => {
         try {
@@ -196,7 +197,7 @@ export default function EditTimeLog({
             </Modal>
             <Modal
                 title="Are you sure you want to delete this time entry?"
-                isModalOpen={isConfirmationModalOpen}
+                isModalOpen={isDeleteConfirmationModalOpen}
                 onClose={toggleDeleteConfirmationModal}
             >
                 <ConfirmationModal confirm={handleDelete} cancel={toggleDeleteConfirmationModal} />


### PR DESCRIPTION
## Title

Add confirmation before time entry deletion.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Hotfix
- [x] UI/UX improvement

## Description

This PR  adds a confirmation model before deleteion to allow a user to be sure a time entry is deleted intentionally as described in this [ticket](https://trello.com/c/WyxhCq8y/201-pop-up-for-deleting-a-time-entry)


## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings/errors.
